### PR TITLE
Add wallet-personalized trust circle Reality Tunnel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,10 +8,12 @@ import { createClient } from "./api";
 import { GetAccountMetadataDocument } from "./vendor/intuition-graphql/dist/index.mjs";
 import RealityTunnel from "./RealityTunnel";
 import EndpointSelector from "./EndpointSelector";
+import TrustCirclePanel from "./TrustCirclePanel";
 
 function App() {
   const [endpoint, setEndpoint] = useState("base");
   const [userFilterAddress, setUserFilterAddress] = useState(null);
+  const [trustGraphData, setTrustGraphData] = useState(null);
   const { address, isConnected } = useAccount();
   const [accountLabel, setAccountLabel] = useState("");
 
@@ -56,8 +58,8 @@ function App() {
           connectedLabel={accountLabel}
         />
         <div className="header-right">
-          <span className="env-badge" title="Using Intuition Testnet API">
-            <span className="env-dot" /> Intuition Testnet
+          <span className="env-badge" title="Using Intuition Mainnet API">
+            <span className="env-dot" /> Intuition Mainnet
           </span>
           <ConnectButton.Custom>
             {({ account, openConnectModal, openAccountModal, mounted }) => {
@@ -85,6 +87,13 @@ function App() {
         <GraphVisualization
           endpoint={endpoint}
           userFilterAddress={userFilterAddress}
+          trustGraphData={trustGraphData}
+        />
+        <TrustCirclePanel
+          endpoint={endpoint}
+          connectedAddress={address}
+          connectedLabel={accountLabel}
+          onGraphData={setTrustGraphData}
         />
       </main>
     </div>

--- a/src/GraphVisualization.js
+++ b/src/GraphVisualization.js
@@ -10,7 +10,7 @@ import GraphVR from "./GraphVR";
 import NodeDetailsSidebar from "./NodeDetailsSidebar";
 import LoadingAnimation from "./LoadingAnimation";
 
-const GraphVisualization = ({ endpoint, userFilterAddress }) => {
+const GraphVisualization = ({ endpoint, userFilterAddress, trustGraphData }) => {
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
   const [initialGraphData, setInitialGraphData] = useState(null);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -338,9 +338,31 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
     }
   }, [shouldSearch, applyFilters]);
 
+  // When the Trust Circle reality tunnel is active, it supplies its own
+  // weighted graph and takes over rendering without disturbing the normal
+  // triples/search state above (so turning it off just falls back to that).
+  const displayGraphData = trustGraphData || graphData;
+
   return (
     <div>
       {(isLoading || isSearching) && <LoadingAnimation />}
+      {trustGraphData && (
+        <div
+          style={{
+            position: "absolute",
+            top: "10px",
+            left: "165px",
+            zIndex: 50,
+            background: "rgba(157, 78, 221, 0.85)",
+            color: "#fff",
+            padding: "6px 10px",
+            borderRadius: "999px",
+            fontSize: "12px",
+          }}
+        >
+          Trust Circle view
+        </div>
+      )}
       <button
         className="navigation-button"
         onClick={resetGraph}
@@ -475,15 +497,16 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
       {viewMode === "2D" && (
         <ForceGraph2D
           ref={(el) => (fgRef.current = el)}
-          graphData={graphData}
+          graphData={displayGraphData}
           nodeCanvasObject={(node, ctx, globalScale) => {
             const label = node.label || "";
-            const fontSize = 12 / globalScale;
+            const sizeScale = node.val || 1;
+            const fontSize = (12 * sizeScale) / globalScale;
             ctx.font = `${fontSize}px Sans-Serif`;
 
             const textWidth = ctx.measureText(label).width;
-            const padding = 10 / globalScale;
-            const radius = 5 / globalScale;
+            const padding = (10 * sizeScale) / globalScale;
+            const radius = (5 * sizeScale) / globalScale;
 
             ctx.fillStyle = node.color + "CC";
             const x = node.x - textWidth / 2 - padding;
@@ -536,6 +559,7 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
               );
           }}
           linkColor={() => "#666"}
+          linkWidth={(link) => link.width || 1}
           linkDirectionalParticles={1}
           linkDirectionalParticleSpeed={0.02}
           linkDirectionalParticleColor={() => "#fff"}
@@ -548,11 +572,12 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
       {viewMode === "3D" && (
         <ForceGraph3D
           ref={(el) => (fgRef.current = el)}
-          graphData={graphData}
+          graphData={displayGraphData}
           controlType="fly"
           nodeLabel="label"
           onNodeClick={handleNodeClick}
           linkColor={() => "#666"}
+          linkWidth={(link) => link.width || 1}
           linkDirectionalParticles={2}
           linkDirectionalParticleSpeed={0.005}
           nodeAutoColorBy="type"
@@ -562,7 +587,7 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
             sprite.backgroundColor = node.color + "CC";
             sprite.padding = 1;
             sprite.color = "#fff";
-            sprite.textHeight = 2;
+            sprite.textHeight = 2 * (node.val || 1);
             return sprite;
           }}
           onEngineStop={handleEngineStop}
@@ -571,7 +596,7 @@ const GraphVisualization = ({ endpoint, userFilterAddress }) => {
 
       {viewMode === "VR" && (
         <GraphVR
-          graphData={graphData}
+          graphData={displayGraphData}
           onNodeClick={handleNodeClick}
           onBack={goBack}
           onForward={goForward}

--- a/src/TrustCirclePanel.js
+++ b/src/TrustCirclePanel.js
@@ -1,0 +1,206 @@
+// src/TrustCirclePanel.js
+//
+// UI for the wallet-personalized Reality Tunnel modes. Lets the connected
+// wallet view the graph through its own on-chain attestations about other
+// accounts, through a specific trusted account's perspective, or through the
+// aggregated view of everyone in its circle.
+import React, { useEffect, useState, useCallback } from "react";
+import { createClient } from "./api";
+import {
+  resolveAccountAtom,
+  fetchOutboundTrustEdges,
+  fetchAggregatedTrustCircle,
+  buildTrustCircleGraph,
+  buildGraphFromTriples,
+} from "./trustCircle";
+
+const MODES = [
+  { id: "mine", label: "My Trust Circle" },
+  { id: "peer", label: "Peer Perspective" },
+  { id: "all", label: "All Trust Circle" },
+];
+
+const panelStyle = {
+  position: "absolute",
+  top: 80,
+  right: 16,
+  zIndex: 3,
+  background: "rgba(0,0,0,0.6)",
+  backdropFilter: "blur(4px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: 8,
+  padding: 12,
+  color: "#fff",
+  width: 300,
+};
+
+export default function TrustCirclePanel({ endpoint, connectedAddress, connectedLabel, onGraphData }) {
+  const [active, setActive] = useState(false);
+  const [mode, setMode] = useState("mine");
+  const [myCircle, setMyCircle] = useState([]); // [{address, label}] for the peer picker
+  const [peerAddress, setPeerAddress] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [summary, setSummary] = useState("");
+
+  const reset = useCallback(() => {
+    setError(null);
+    setSummary("");
+    onGraphData(null);
+  }, [onGraphData]);
+
+  // Turning the trust tunnel off, or disconnecting the wallet, restores the
+  // normal graph view.
+  useEffect(() => {
+    if (!connectedAddress || !active) {
+      reset();
+    }
+  }, [connectedAddress, active, reset]);
+
+  useEffect(() => {
+    if (!active || !connectedAddress) return;
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const client = createClient(endpoint);
+
+        if (mode === "mine") {
+          const root = await resolveAccountAtom(client, connectedAddress);
+          if (!root) {
+            if (!cancelled) {
+              setSummary("This wallet has no atom on-chain yet — nothing to build a trust circle from.");
+              onGraphData(null);
+              setMyCircle([]);
+            }
+            return;
+          }
+          const edges = await fetchOutboundTrustEdges(client, root.atomId, root.address);
+          if (cancelled) return;
+          setMyCircle(edges.map((e) => ({ address: e.target.address, label: e.target.label })));
+          if (edges.length === 0) {
+            setSummary(`${root.label} hasn't made any on-chain claims about other accounts yet.`);
+            onGraphData(null);
+            return;
+          }
+          setSummary(`${edges.length} account${edges.length === 1 ? "" : "s"} this wallet has attested about.`);
+          onGraphData(buildTrustCircleGraph(root, edges));
+        } else if (mode === "peer") {
+          if (!peerAddress) {
+            setSummary("Pick someone from your trust circle to view the graph through their perspective.");
+            onGraphData(null);
+            return;
+          }
+          const peer = await resolveAccountAtom(client, peerAddress);
+          if (!peer) {
+            setSummary("Could not resolve that account on-chain.");
+            onGraphData(null);
+            return;
+          }
+          const edges = await fetchOutboundTrustEdges(client, peer.atomId, peer.address);
+          if (cancelled) return;
+          if (edges.length === 0) {
+            setSummary(`${peer.label} hasn't made any on-chain claims about other accounts yet.`);
+            onGraphData(null);
+            return;
+          }
+          setSummary(`Viewing the graph through ${peer.label}'s ${edges.length} attestation${edges.length === 1 ? "" : "s"}.`);
+          onGraphData(buildTrustCircleGraph(peer, edges));
+        } else if (mode === "all") {
+          const { root, rootEdges, triples, edgeCount } = await fetchAggregatedTrustCircle(client, connectedAddress);
+          if (cancelled) return;
+          if (!root || edgeCount === 0) {
+            setSummary(
+              root
+                ? `${root.label} hasn't made any on-chain claims about other accounts yet.`
+                : "This wallet has no atom on-chain yet — nothing to build a trust circle from."
+            );
+            onGraphData(null);
+            setMyCircle([]);
+            return;
+          }
+          setMyCircle(rootEdges.map((e) => ({ address: e.target.address, label: e.target.label })));
+          setSummary(
+            `Aggregated view: ${root.label}'s circle (${edgeCount} direct) plus who they trust, ${triples.length} claims total.`
+          );
+          onGraphData(buildGraphFromTriples(triples));
+        }
+      } catch (e) {
+        console.error("Error building trust circle graph:", e);
+        if (!cancelled) {
+          setError("Could not load trust circle data from mainnet.");
+          onGraphData(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, mode, peerAddress, connectedAddress, endpoint]);
+
+  if (!connectedAddress) return null;
+
+  return (
+    <section style={panelStyle}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h3 style={{ margin: 0, fontSize: 14 }}>Reality Tunnel: Trust Circle</h3>
+        <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={active} onChange={(e) => setActive(e.target.checked)} />
+          Enabled
+        </label>
+      </div>
+
+      {active && (
+        <>
+          <div style={{ display: "flex", gap: 6, margin: "10px 0" }}>
+            {MODES.map((m) => (
+              <button
+                key={m.id}
+                className="navigation-button"
+                onClick={() => setMode(m.id)}
+                style={{
+                  fontSize: 11,
+                  padding: "4px 8px",
+                  opacity: mode === m.id ? 1 : 0.6,
+                  border: mode === m.id ? "1px solid #fff" : undefined,
+                }}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+
+          {mode === "peer" && (
+            <select
+              className="tunnel-select"
+              value={peerAddress}
+              onChange={(e) => setPeerAddress(e.target.value)}
+              style={{ width: "100%", marginBottom: 8 }}
+              disabled={myCircle.length === 0}
+            >
+              <option value="">
+                {myCircle.length === 0 ? "No one in your circle yet" : "Select a person from your circle"}
+              </option>
+              {myCircle.map((p) => (
+                <option key={p.address} value={p.address}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {loading && <p style={{ fontSize: 12, color: "#ccc" }}>Loading from mainnet…</p>}
+          {error && <p style={{ fontSize: 12, color: "#f88" }}>{error}</p>}
+          {!loading && !error && summary && <p style={{ fontSize: 12, color: "#ccc" }}>{summary}</p>}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/api.js
+++ b/src/api.js
@@ -15,8 +15,8 @@ export const ENDPOINTS = {
     module: BaseSepolia,
   },
   base: {
-    url: "https://testnet.intuition.sh/v1/graphql",
-    displayName: "Intuition Testnet",
+    url: "https://mainnet.intuition.sh/v1/graphql",
+    displayName: "Intuition Mainnet",
     module: Base,
   },
 };

--- a/src/api/Base.js
+++ b/src/api/Base.js
@@ -6,8 +6,8 @@ import {
 
 export const ENDPOINTS = {
   base: {
-    url: "https://testnet.intuition.sh/v1/graphql",
-    displayName: "Intuition Testnet",
+    url: "https://mainnet.intuition.sh/v1/graphql",
+    displayName: "Intuition Mainnet",
   },
 };
 // Create GraphQL client based on endpoint

--- a/src/trustCircle.js
+++ b/src/trustCircle.js
@@ -1,0 +1,192 @@
+// src/trustCircle.js
+//
+// Data layer for the wallet-personalized "Reality Tunnel" trust circle.
+//
+// Intuition is permissionless: there is no single canonical "trust" or
+// "follows" predicate atom (mainnet has multiple independently-created atoms
+// labeled "trusts"/"follows"). The structural signal that actually exists at
+// volume is: a triple whose subject is the connected wallet's Account atom
+// and whose object is another Account atom — i.e. "this wallet made an
+// on-chain claim about that wallet", backed by a real vault position. That is
+// what this module treats as a "trust circle" edge.
+import { transformToGraphData } from "./graphData";
+
+const CURVE_ID = "1";
+
+const ACCOUNT_ATOM_QUERY = `
+  query TrustCircleAccountAtom($address: String!) {
+    accounts(where: { id: { _ilike: $address } }, limit: 1) {
+      id
+      label
+      atom_id
+    }
+  }
+`;
+
+const OUTBOUND_ACCOUNT_TRIPLES_QUERY = `
+  query TrustCircleOutboundTriples($atomId: numeric!, $viewer: String!) {
+    triples(
+      where: { subject_id: { _eq: $atomId }, object: { type: { _eq: "Account" } } }
+    ) {
+      term_id
+      predicate {
+        term_id
+        label
+      }
+      object {
+        term_id
+        label
+        wallet_id
+      }
+      term {
+        vaults(where: { curve_id: { _eq: "${CURVE_ID}" } }) {
+          total_shares
+          positions(where: { account_id: { _ilike: $viewer } }) {
+            shares
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Resolve a wallet address to its Account atom (the node representing that
+// wallet in the knowledge graph). Returns null if the address has no atom yet
+// (e.g. it has never interacted with the protocol).
+export async function resolveAccountAtom(client, address) {
+  if (!address) return null;
+  const data = await client.request(ACCOUNT_ATOM_QUERY, { address });
+  const account = data?.accounts?.[0];
+  if (!account || !account.atom_id) return null;
+  return {
+    address: account.id,
+    label: account.label || account.id,
+    atomId: account.atom_id,
+  };
+}
+
+// Fetch the on-chain claims `rootAddress` has made about other accounts
+// (the outbound edges of its trust circle), with stake-based weighting.
+export async function fetchOutboundTrustEdges(client, atomId, rootAddress) {
+  const data = await client.request(OUTBOUND_ACCOUNT_TRIPLES_QUERY, {
+    atomId,
+    viewer: rootAddress,
+  });
+  const triples = data?.triples || [];
+  return triples
+    .map((t) => {
+      const vault = t.term?.vaults?.[0];
+      const totalShares = Number(vault?.total_shares || 0);
+      const ownShares = Number(vault?.positions?.[0]?.shares || 0);
+      return {
+        id: t.term_id,
+        predicateLabel: t.predicate?.label || "is related to",
+        target: {
+          atomId: t.object?.term_id || null,
+          address: t.object?.wallet_id || null,
+          label: t.object?.label || t.object?.wallet_id || "Unknown",
+        },
+        totalShares,
+        ownShares,
+        // Prefer the stake the root account itself put behind the claim;
+        // fall back to the vault's total shares so unstaked claims still
+        // render with some weight rather than collapsing to zero.
+        weight: ownShares > 0 ? ownShares : totalShares,
+      };
+    })
+    .filter((edge) => edge.target.address);
+}
+
+// Turn trust-circle edges rooted at `root` into the {subject, predicate,
+// object} triple shape `transformToGraphData` already understands, carrying
+// the edge weight along for downstream node/link sizing.
+export function edgesToTriples(root, edges) {
+  return edges.map((edge) => ({
+    id: edge.id,
+    subject: { id: root.address, label: root.label },
+    predicate: { id: `${edge.id}-predicate`, label: edge.predicateLabel },
+    object: { id: edge.target.address, label: edge.target.label },
+    weight: edge.weight,
+  }));
+}
+
+// Apply weight-derived `val` (node size) and `width` (link size) to graph
+// data produced by transformToGraphData, so stake/attestation strength is
+// visible. Falls back to 1 for anything we have no weight for.
+function applyWeighting(graphData, triples) {
+  const weightByObjectId = new Map();
+  triples.forEach((t) => {
+    const prev = weightByObjectId.get(t.object.id) || 0;
+    weightByObjectId.set(t.object.id, Math.max(prev, t.weight || 0));
+  });
+  const maxWeight = Math.max(1, ...weightByObjectId.values());
+
+  const nodes = graphData.nodes.map((node) => {
+    const raw = weightByObjectId.get(node.id);
+    if (raw === undefined) return node;
+    const normalized = 1 + 4 * Math.sqrt(raw / maxWeight);
+    return { ...node, val: normalized };
+  });
+
+  const weightByTripleId = new Map(triples.map((t) => [t.id, t.weight || 0]));
+  const tripleIdFromPredicateNodeId = (predicateNodeId) =>
+    String(predicateNodeId).replace(/-predicate$/, "");
+
+  const links = graphData.links.map((link) => {
+    let tripleId = null;
+    if (link.type === "subject-to-predicate") tripleId = tripleIdFromPredicateNodeId(link.target);
+    else if (link.type === "predicate-to-object") tripleId = tripleIdFromPredicateNodeId(link.source);
+
+    const raw = tripleId ? weightByTripleId.get(tripleId) : undefined;
+    if (raw === undefined) return link;
+    const normalized = 1 + 3 * Math.sqrt(raw / maxWeight);
+    return { ...link, width: normalized };
+  });
+
+  return { nodes, links };
+}
+
+// Build render-ready graph data (nodes/links with weight-derived sizing)
+// from a flat list of trust-circle triples, regardless of how many roots
+// they came from (single-perspective or aggregated).
+export function buildGraphFromTriples(triples) {
+  const base = transformToGraphData(triples);
+  return applyWeighting(base, triples);
+}
+
+// Build render-ready graph data for a single root's outbound trust circle.
+export function buildTrustCircleGraph(root, edges) {
+  return buildGraphFromTriples(edgesToTriples(root, edges));
+}
+
+// "All trust circle": root's own outbound edges, plus one more hop — the
+// outbound edges of everyone in root's circle — merged into one graph.
+export async function fetchAggregatedTrustCircle(client, rootAddress) {
+  const root = await resolveAccountAtom(client, rootAddress);
+  if (!root) return { root: null, triples: [], edgeCount: 0 };
+
+  const rootEdges = await fetchOutboundTrustEdges(client, root.atomId, root.address);
+  const allTriples = edgesToTriples(root, rootEdges);
+
+  const hopTriples = await Promise.all(
+    rootEdges.map(async (edge) => {
+      if (!edge.target.atomId) return [];
+      const peer = {
+        address: edge.target.address,
+        label: edge.target.label,
+        atomId: edge.target.atomId,
+      };
+      try {
+        const peerEdges = await fetchOutboundTrustEdges(client, peer.atomId, peer.address);
+        return edgesToTriples(peer, peerEdges);
+      } catch (e) {
+        console.error("Error fetching second-hop trust edges for", peer.address, e);
+        return [];
+      }
+    })
+  );
+
+  hopTriples.forEach((triples) => allTriples.push(...triples));
+
+  return { root, rootEdges, triples: allTriples, edgeCount: rootEdges.length };
+}


### PR DESCRIPTION
## Summary

Resolves the Reality Tunnel half of #45 — adds the three wallet-personalized
trust circle modes from the original spec, complementing the mainnet
migration and trust-threshold filter already in #47.

This is additive: #47's global "Trust Threshold" slider filters the whole
graph by raw vault share weight, regardless of who's connected. It doesn't
use the connected wallet's own attestations. This PR fills that specific
gap.

## What's included

### Reality Tunnel — wallet-personalized trust circle
- **My Trust Circle** — graph built from the connected wallet's own
  on-chain attestations about other accounts (`src/trustCircle.js`,
  `src/TrustCirclePanel.js`)
- **Peer Perspective** — pick someone from your circle and view the graph
  rooted at their attestations instead
- **All Trust Circle** — aggregated view: your circle plus a second hop
  (who the people you trust, trust)
- **Weighting** — node size and link width scaled by real vault stake on
  each attestation (`applyWeighting` in `src/trustCircle.js`,
  `nodeVal`/`linkWidth` wiring in `GraphVisualization.js`)

### A note on what "trust circle" means here
Intuition is permissionless — there's no single canonical "trust" or
"follows" predicate atom. I checked mainnet directly: there are multiple
independently-created atoms labeled "trusts"/"follows", and the one atom
matching the SDK's `following`/`followers` helpers has only 2 instances on
all of mainnet. Not enough to build a feature on.

Instead, this defines a trust-circle edge structurally: a triple where the
connected wallet's Account atom is the subject and another Account atom is
the object — i.e. "this wallet made an on-chain claim about that wallet."
That pattern has real volume (~1,002 such triples mainnet-wide as of
writing) and is exactly what the protocol already treats as an attestation
(a triple backed by a vault position). Predicate labels vary ("follows",
"trusts", "recommends", "is a member of", etc.) — the structural pattern is
the trust signal, not a specific word choice.

This was verified against live queries to `mainnet.intuition.sh/v1/graphql`
before writing any code, not assumed or mocked.

### Mainnet migration
Also included so this branch is self-contained and testable on its own —
same endpoint swap as #47 (`api.js`, `api/Base.js`, env badge).

## Testing
1. Connect a wallet that has made on-chain attestations about other
   accounts (most wallets currently have none — mainnet trust-circle data
   is still sparse; the panel says so explicitly rather than faking
   results)
2. Enable the "Reality Tunnel: Trust Circle" panel (top right)
3. Switch between My Trust Circle / Peer Perspective / All Trust Circle
4. Confirm node size and edge thickness scale with stake
5. Disable the panel to confirm the graph falls back to normal behavior